### PR TITLE
Downgrade to Java 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
             - uses: actions/setup-java@v2
               with:
                   distribution: 'temurin'
-                  java-version: '17'
+                  java-version: '8'
             - uses: actions/cache@v2
               with:
                   path: ~/.m2/repository

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>8</maven.compiler.target>
 
         <junit-platform.version>1.8.2</junit-platform.version>
-        <commonmark.version>0.17.0</commonmark.version>
+        <commonmark.version>0.18.2</commonmark.version>
 
         <junit.version>5.8.2</junit.version>
 
@@ -58,7 +58,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.atlassian.commonmark</groupId>
+            <groupId>org.commonmark</groupId>
             <artifactId>commonmark</artifactId>
             <version>${commonmark.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
 
         <junit-platform.version>1.8.2</junit-platform.version>
         <commonmark.version>0.17.0</commonmark.version>

--- a/src/main/java/com/github/fridujo/markdown/junit/engine/visitor/ContainerNode.java
+++ b/src/main/java/com/github/fridujo/markdown/junit/engine/visitor/ContainerNode.java
@@ -2,19 +2,32 @@ package com.github.fridujo.markdown.junit.engine.visitor;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public record ContainerNode(String name, Collection<TestNode> children) implements TestNode {
+public class ContainerNode implements TestNode {
+
+    private final String name;
+    private final Collection<TestNode> children;
 
     public ContainerNode(String name, Collection<TestNode> children) {
         this.name = name;
-        this.children = List.copyOf(children);
+        this.children = Collections.unmodifiableList(new ArrayList<>(children));
+    }
+
+    @Override
+    public String name() {
+        return name;
     }
 
     @Override
     public TestNode.Type type() {
         return TestNode.Type.CONTAINER;
+    }
+
+    public Collection<TestNode> children() {
+        return children;
     }
 
     public static class Builder implements TestNode.Builder {
@@ -34,7 +47,7 @@ public record ContainerNode(String name, Collection<TestNode> children) implemen
         public ContainerNode build() {
             List<TestNode> builtChildren = children.stream()
                 .map(TestNode.Builder::build)
-                .filter(tn -> !(tn.type() == Type.CONTAINER && ContainerNode.class.cast(tn).children.isEmpty()))
+                .filter(tn -> !(tn.type() == Type.CONTAINER && ((ContainerNode) tn).children.isEmpty()))
                 .collect(Collectors.toList());
             return new ContainerNode(name, builtChildren);
         }

--- a/src/main/java/com/github/fridujo/markdown/junit/engine/visitor/RunnableNode.java
+++ b/src/main/java/com/github/fridujo/markdown/junit/engine/visitor/RunnableNode.java
@@ -1,13 +1,38 @@
 package com.github.fridujo.markdown.junit.engine.visitor;
 
-public record RunnableNode(String name, Runnable runnable) implements TestNode {
+public class RunnableNode implements TestNode {
+
+    private final String name;
+    private final Runnable runnable;
+
+    public RunnableNode(String name, Runnable runnable) {
+        this.name = name;
+        this.runnable = runnable;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
 
     @Override
     public Type type() {
         return Type.TEST;
     }
 
-    public record Builder(String name, Runnable runnable) implements TestNode.Builder {
+    public Runnable runnable() {
+        return runnable;
+    }
+
+    public static class Builder implements TestNode.Builder {
+
+        private final String name;
+        private final Runnable runnable;
+
+        public Builder(String name, Runnable runnable) {
+            this.name = name;
+            this.runnable = runnable;
+        }
 
         @Override
         public RunnableNode build() {
@@ -17,6 +42,11 @@ public record RunnableNode(String name, Runnable runnable) implements TestNode {
         @Override
         public Type type() {
             return Type.TEST;
+        }
+
+        @Override
+        public String name() {
+            return name;
         }
     }
 }

--- a/src/main/java/com/github/fridujo/markdown/junit/engine/visitor/TestNode.java
+++ b/src/main/java/com/github/fridujo/markdown/junit/engine/visitor/TestNode.java
@@ -1,6 +1,6 @@
 package com.github.fridujo.markdown.junit.engine.visitor;
 
-public sealed interface TestNode permits ContainerNode, RunnableNode {
+public interface TestNode {
 
     String name();
 

--- a/src/test/java/com/github/fridujo/markdown/junit/engine/visitor/TestVisitorFactory.java
+++ b/src/test/java/com/github/fridujo/markdown/junit/engine/visitor/TestVisitorFactory.java
@@ -3,8 +3,8 @@ package com.github.fridujo.markdown.junit.engine.visitor;
 import org.commonmark.node.AbstractVisitor;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 public class TestVisitorFactory implements MarkdownVisitorFactory {
 
@@ -17,8 +17,8 @@ public class TestVisitorFactory implements MarkdownVisitorFactory {
 
         @Override
         public Collection<TestNode> getCollectedTestNode() {
-            return List.of(new RunnableNode("Test1", () -> {
-            }), new ContainerNode("Container2", List.of(new RunnableNode("Test2.1", () -> {
+            return Arrays.asList(new RunnableNode("Test1", () -> {
+            }), new ContainerNode("Container2", Arrays.asList(new RunnableNode("Test2.1", () -> {
                 throw new RuntimeException("failure");
             }), new RunnableNode("Test2.2", () -> {
             }))));


### PR DESCRIPTION
As most published binaries want maximum compatibility, and Java 8 is the
lowest we can go for using JUnit 5.